### PR TITLE
Allow for third-party Xbox 360 controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,37 @@ Cylon.robot
 .start()
 ```
 
+## Third-Party Controllers
+
+For Xbox 360 third-party controllers, you may need to supply part of the name to
+the `connection` so that our driver can find your controller correctly. To find
+out the name of the controller, you can run [this script](https://gist.github.com/stewart/9011885).
+
+Example:
+
+```javascript
+var Cylon = require('cylon');
+
+Cylon.robot({
+  connection: {
+    name: 'joystick',
+    adaptor: 'joystick',
+    controller: 'xbox360',
+    type: 'afterglow' // <= lets cylon-joystick connect to your controller
+  },
+
+  device: { name: 'joystick', driver: 'xbox360' },
+
+  work: function(my) {
+    my.joystick.on("left:move", function(position) { 
+      console.log(position);
+    });
+  }
+}).start();
+```
+
+Third party controller support for PS3 is pending.
+
 ## Documentation
 
 We're busy adding documentation to our web site at http://cylonjs.com/ please check there as we continue to work on Cylon.js

--- a/dist/adaptors/xbox360.js
+++ b/dist/adaptors/xbox360.js
@@ -24,21 +24,23 @@
       __extends(Xbox360, _super);
 
       function Xbox360(opts) {
+        var type;
         if (opts == null) {
           opts = {};
         }
+        type = opts.extraParams.type || "controller";
         if (opts.initialize == null) {
           opts.initialize = true;
         }
         this.joystick = null;
         Xbox360.__super__.constructor.apply(this, arguments);
         if (opts.initialize) {
-          this.connectToController();
+          this.connectToController(type);
         }
       }
 
-      Xbox360.prototype.connectToController = function() {
-        this.connector = this.joystick = new XboxController;
+      Xbox360.prototype.connectToController = function(type) {
+        this.connector = this.joystick = new XboxController(type);
         return this.proxyMethods(this.commands(), this.joystick, this);
       };
 

--- a/src/adaptors/xbox360.coffee
+++ b/src/adaptors/xbox360.coffee
@@ -16,13 +16,14 @@ require '../cylon-joystick'
 namespace "Cylon.Adaptors.Joystick", ->
   class @Xbox360 extends Cylon.Adaptor
     constructor: (opts = {}) ->
+      type = opts.extraParams.type || "controller"
       opts.initialize ?= true
       @joystick = null
       super
-      do @connectToController if opts.initialize
+      @connectToController(type) if opts.initialize
 
-    connectToController: ->
-      @connector = @joystick = new XboxController
+    connectToController: (type) ->
+      @connector = @joystick = new XboxController(type)
       @proxyMethods @commands(), @joystick, this
 
     commands: ->


### PR DESCRIPTION
`node-xbox-controller` finds controllers by their name in the HID devices, but
needs to be informed about third-party controllers that don't necessarily label
themselves as 'controller' (as the official 360 controller does).

Users can now specify a string for `node-xbox-controller` to use when attempting
to hook up to a controller by specifying their connection like this:

``` coffeescript
Cylon.robot
  connection:
    name: "controller"
    adaptor: "joystick"
    controller: "xbox360"
    type: "afterglow" # <= tells node-xbox-controller what to look for
```
