### PR TITLE
Remove extra function names for prototypes

### DIFF
--- a/lib/adaptor.js
+++ b/lib/adaptor.js
@@ -24,7 +24,7 @@ var Adaptor = module.exports = function Adaptor(opts) {
 
 Cylon.Utils.subclass(Adaptor, Cylon.Adaptor);
 
-Adaptor.prototype.connect = function connect(callback) {
+Adaptor.prototype.connect = function(callback) {
   SDL.init(SDL.INIT.JOYSTICK);
 
   if (SDL.numJoysticks() === 0) {
@@ -38,12 +38,12 @@ Adaptor.prototype.connect = function connect(callback) {
   callback();
 };
 
-Adaptor.prototype.disconnect = function disconnect(callback) {
+Adaptor.prototype.disconnect = function(callback) {
   SDL.quit();
   callback();
 };
 
-Adaptor.prototype.listenForEvents = function listenForEvents() {
+Adaptor.prototype.listenForEvents = function() {
   var event = SDL.pollEvent();
 
   if (!event) {

--- a/lib/driver.js
+++ b/lib/driver.js
@@ -24,16 +24,16 @@ var Driver = module.exports = function Driver(opts) {
 
 Cylon.Utils.subclass(Driver, Cylon.Driver);
 
-Driver.prototype.start = function start(callback) {
+Driver.prototype.start = function(callback) {
   this.connection.on('event', this.handleSDLEvent.bind(this));
   callback();
 };
 
-Driver.prototype.halt = function start(callback) {
+Driver.prototype.halt = function(callback) {
   callback();
 };
 
-Driver.prototype.handleSDLEvent = function handleSDLEvent(event) {
+Driver.prototype.handleSDLEvent = function(event) {
   var button = null;
 
   switch (event.type) {
@@ -54,7 +54,7 @@ Driver.prototype.handleSDLEvent = function handleSDLEvent(event) {
   }
 };
 
-Driver.prototype.findInConfig = function findInConfig(type, id) {
+Driver.prototype.findInConfig = function(type, id) {
   for (var a = 0; a < this.config[type].length; a++) {
     var thing = this.config[type][a];
 


### PR DESCRIPTION
Looks like something went awry when updating this module with some extra function names... This PR removes them.
